### PR TITLE
Tweaked for set -u.

### DIFF
--- a/git-archive-all
+++ b/git-archive-all
@@ -261,7 +261,7 @@ process_subtree()
 				if [[ "$include_full" == 1 || "${#included_paths[@]}" -gt 0 ]]
 				then
 					# This submodule will contribute to our final archive.
-					process_subtree "$modtree_ish" "${subprefix}${modpath}" "$recursive" "${included_paths[@]}"
+					process_subtree "$modtree_ish" "${subprefix}${modpath}" "$recursive" ${included_paths:+"${included_paths[@]}"}
 				fi
 			fi
 		fi
@@ -289,7 +289,7 @@ process_subtree()
 		if [[ $# -eq 0 || ${#subpaths[@]} -gt 0 ]]
 		then
 			archive="$workdir/${#subtars[@]}.tar"
-			run git ${subprefix:+-C "$subprefix"} archive "${extra_args[@]}" -o "$archive" ${fullprefix:+--prefix="${fullprefix}"} "$subtree_ish" "${subpaths[@]}"
+			run git ${subprefix:+-C "$subprefix"} archive ${extra_args:+"${extra_args[@]}"} -o "$archive" ${fullprefix:+--prefix="${fullprefix}"} "$subtree_ish" ${subpaths:+"${subpaths[@]}"}
 			subtars+=("$archive")
 		fi
 		if [[ -z "$subprefix" && ${#subtars[@]} -eq 0 && $# -gt 0 ]]
@@ -307,7 +307,7 @@ process_subtree()
 		if [[ -n "$subprefix" ]]
 		then
 				archive="$workdir/${#subtars[@]}.tar"
-				if ! run git -C "$subprefix" archive "${extra_args[@]}" -o "$archive" --prefix="${fullprefix}" "$subtree_ish" "$@"
+				if ! run git -C "$subprefix" archive ${extra_args:+"${extra_args[@]}"} -o "$archive" --prefix="${fullprefix}" "$subtree_ish" "$@"
 				then
 					if [[ "$fail_missing" == 1 ]]
 					then
@@ -382,7 +382,7 @@ then
 else
 	# If there are no submodules, fall back to the regular git archive command
 	# for maximum compatibility
-	run git archive "${extra_args[@]}" ${format:+--format="$format"} ${outfile:+-o "$outfile"} ${prefix:+--prefix="${prefix}"} $compress_flag "$tree_ish" "$@"
+	run git archive ${extra_args:+"${extra_args[@]}"} ${format:+--format="$format"} ${outfile:+-o "$outfile"} ${prefix:+--prefix="${prefix}"} $compress_flag "$tree_ish" "$@"
 fi
 exit $?
 


### PR DESCRIPTION
It looks like `set -u` recently introduced in b631b80d80ea6f8d3443daada46f8d1151977f7b causes a few failures here and there, like below (reproducing it with stock GNU bash, version 3.2.57 on macOS):

```
$ git-archive-all a8b108791bf8e162c1076d995a5bd9578c906691 |tar tf -
git-archive-all: cannot determine archive format from file name, using 'tar'
git-archive-all: line 385: extra_args[@]: unbound variable
```

This PR just fixes the script so that `"${array[@]}"` would not cause failure when `array` is empty, by replacing such fragments with `${array:+"${array[@]}"}`, that should attempt to expand `array` only when it's not empty. (I'm not sure that I covered all the cases, but those were those I encountered in real life).