### PR TITLE
Added README for macOS to cover GNU getopt/tar.

### DIFF
--- a/README-macOS.md
+++ b/README-macOS.md
@@ -1,0 +1,9 @@
+Beware that the script requires GNU variants of getopt and tar.
+
+On macOS you can use Homebrew to install those:
+
+    brew install gnu-getopt
+    brew install gnu-tar
+
+Remember to follow Homebrew instructions to setup PATH, so that the above variants of the tools are found **before** the stock ones.
+


### PR DESCRIPTION
On macOS the script does not work correctly, unless we force use of GNU getopt and GNU tar. This PR adds README to cover the possible workaround (installing GNU variants via Homebrew).

For the reference, GNU tar is required for `tar -A`, that is concatenating two archives, that option is not supported by stock tar from FreeBSD?.

What is the exact problem with getopt, I don't know, but stock completely messes ups things (even the argument count remaining after the invocation). Enforcing GNU getopt solves the problem for sure. Below is a bit of diagnostic from stock getopt.

```
$ bash -x ~/GitHub/git-archive-all/git-archive-all a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar
+ set -euo pipefail
+ self=git-archive-all
+ self=git-archive-all
+ version=1.3.0
+ whsp='               '
+ outfile=
+ prefix=
+ format=
+ verbose=0
+ recursive=1
+ fail_missing=0
+ worktree_attributes=0
+ compress_flag=
++ getopt -n git-archive-all -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar
+ options=' -- git-archive-all -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar'
+ eval 'set --  -- git-archive-all -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar'
++ set -- -- git-archive-all -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar
+ [[ 10 -gt 0 ]]
+ case "$1" in
+ shift
+ break
+ tree_ish=git-archive-all
+ shift
+ extra_args=()
+ quiet_flag=-q
+ [[ 0 -ge 2 ]]
+ [[ 0 -eq 0 ]]
+ [[ -z '' ]]
+ case "$outfile" in
+ echo 'git-archive-all: cannot determine archive format from file name, using '\''tar'\'''
git-archive-all: cannot determine archive format from file name, using 'tar'
+ format=tar
+ case "$format" in
++ mktemp -d
+ workdir=/var/folders/mp/3jr0hvr922v_32bx7309bntr0000gn/T/tmp.uikI5qa2
+ trap cleanup EXIT
+ subtars=()
+ process_subtree git-archive-all '' 1 -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar
+ local subtree_ish=git-archive-all subprefix= sub_recursive=1
+ shift 3
+ modulepaths=()
+ local modulepaths fullprefix=
+ local included_paths include_full fmode ftype modtree_ish modpath archive
+ read -d '' fmode ftype modtree_ish modpath
++ git ls-tree -r -z git-archive-all
+ [[ 0 -gt 0 ]]
+ [[ -n '' ]]
+ [[ 0 -gt 0 ]]
+ run git archive --format=tar git-archive-all -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar
+ [[ 0 -gt 0 ]]
+ git archive --format=tar git-archive-all -o hlrv0123456789o: -l help,list,version,verbose,worktree-attributes,recursive,no-recursive,fail-missing,format:,output:,prefix: -- a8b108791bf8e162c1076d995a5bd9578c906691 -o x.tar
+ exit 0
+ cleanup
+ rm -rf /var/folders/mp/3jr0hvr922v_32bx7309bntr0000gn/T/tmp.uikI5qa2
```